### PR TITLE
Update Kyverno chart version from 3.2.5 to 3.4.4

### DIFF
--- a/internal/policy/kyverno.go
+++ b/internal/policy/kyverno.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	kyvernoChartName    = "kyverno"
-	kyvernoChartVersion = "3.2.5"
+	kyvernoChartVersion = "3.4.4"
 	kyvernoReleaseName  = "kyverno"
 	kyvernoRepoUrl      = "https://kyverno.github.io/kyverno/"
 	kyvernoNamespace    = "kyverno"


### PR DESCRIPTION
## Summary
  Updated Kyverno chart version from 3.2.5 to 3.4.4 to address Bitnami image registry restrictions while maintaining Kubernetes 1.26 compatibility.

  ## Motivation
  Bitnami container images are now only available under the `latest` tag, causing Kyverno 3.2.5 to fail when pulling images. The updated version uses `reg.kyverno.io` as the default
  registry, resolving this issue.

  ## Changes
  - Updated `kyvernoChartVersion` in `internal/policy/kyverno.go` from "3.2.5" to "3.4.4"

  ## Why 3.4.4 Instead of 3.5.2?
  - **Includes Bitnami fix**: Uses `reg.kyverno.io` default registry
  - **K8s 1.26 compatible**: Doesn't require `ValidatingAdmissionPolicy` CRD (K8s 1.30+ feature)
  - **Minimal changes**: Closest to 3.2.5 with stable features
  - **Latest stable**: v1.14.4 patch release in 3.4.x series

  ## Testing
  - ✅ Deployed successfully in KinD cluster (Kubernetes 1.26.3)
  - ✅ TLS certificates auto-generated correctly
  - ✅ Admission controller running (1/1 Ready)
  - ✅ All webhooks registered (5 validating, 3 mutating)
  - ✅ Created local registry with ClusterPolicy working correctly

  ## Breaking Changes
  None. Maintains backward compatibility within Kyverno 3.x series.